### PR TITLE
Verify signature

### DIFF
--- a/cmd/nearcall/nearcall.go
+++ b/cmd/nearcall/nearcall.go
@@ -41,7 +41,7 @@ func GoCall(network, accountID, contract, method, argfile string) (string, inter
 	if err != nil {
 		return arghash, nil, err
 	}
-	resp, err := account.FunctionCall(contract, method, args, 100_000_000_000_000, *(big.NewInt(0)))
+	resp, err := account.FunctionCall(contract, method, args, 10_000_000_000_000, *(big.NewInt(0)))
 	if err != nil {
 		return arghash, nil, err
 	}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -32,6 +32,11 @@ func GenerateEd25519KeyPair(accountID string) (*Ed25519KeyPair, error) {
 	return KeyPairFromPrivateKey(accountID, privateKey), nil
 }
 
+// ParseEd25519PrivateKey parses a private key string and returns an ed25519.PrivateKey.
+func ParseEd25519PrivateKey(privateKeyString string) (ed25519.PrivateKey, error) {
+	return utils.Ed25519PrivateKeyFromString(privateKeyString)
+}
+
 // KeyPairFromPrivateKey creates a key-pair given an accountID and a private key.
 func KeyPairFromPrivateKey(accountID string, privateKey ed25519.PrivateKey) *Ed25519KeyPair {
 	publicKey := privateKey.Public().(ed25519.PublicKey)

--- a/transaction.go
+++ b/transaction.go
@@ -5,129 +5,32 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
-	"math/big"
 
-	"github.com/aurora-is-near/near-api-go/utils"
+	"github.com/aurora-is-near/near-api-go/types"
 	"github.com/near/borsh-go"
 )
 
-// AccessKey encodes a NEAR access key.
-type AccessKey struct {
-	Nonce      uint64
-	Permission AccessKeyPermission
-}
-
-// AccessKeyPermission encodes a NEAR access key permission.
-type AccessKeyPermission struct {
-	Enum         borsh.Enum `borsh_enum:"true"` // treat struct as complex enum when serializing/deserializing
-	FunctionCall FunctionCallPermission
-	FullAccess   borsh.Enum
-}
-
-// FunctionCallPermission encodes a NEAR function call permission (an access
-// key permission).
-type FunctionCallPermission struct {
-	Allowance   *big.Int
-	ReceiverId  string
-	MethodNames []string
-}
-
-func fullAccessKey() AccessKey {
-	return AccessKey{
+func fullAccessKey() types.AccessKey {
+	return types.AccessKey{
 		Nonce: 0,
-		Permission: AccessKeyPermission{
+		Permission: types.AccessKeyPermission{
 			Enum:       1,
 			FullAccess: 1,
 		},
 	}
 }
 
-// A Transaction encodes a NEAR transaction.
-type Transaction struct {
-	SignerID   string
-	PublicKey  utils.PublicKey
-	Nonce      uint64
-	ReceiverID string
-	BlockHash  [32]byte
-	Actions    []Action
-}
-
-// Action simulates an enum for Borsh encoding.
-type Action struct {
-	Enum           borsh.Enum `borsh_enum:"true"` // treat struct as complex enum when serializing/deserializing
-	CreateAccount  borsh.Enum
-	DeployContract DeployContract
-	FunctionCall   FunctionCall
-	Transfer       Transfer
-	Stake          Stake
-	AddKey         AddKey
-	DeleteKey      DeleteKey
-	DeleteAccount  DeleteAccount
-}
-
-// The DeployContract action.
-type DeployContract struct {
-	Code []byte
-}
-
-// The FunctionCall action.
-type FunctionCall struct {
-	MethodName string
-	Args       []byte
-	Gas        uint64
-	Deposit    big.Int // u128
-}
-
-// The Transfer action.
-type Transfer struct {
-	Deposit big.Int // u128
-}
-
-// The Stake action.
-type Stake struct {
-	Stake     big.Int // u128
-	PublicKey utils.PublicKey
-}
-
-// The AddKey action.
-type AddKey struct {
-	PublicKey utils.PublicKey
-	AccessKey AccessKey
-}
-
-// The DeleteKey action.
-type DeleteKey struct {
-	PublicKey utils.PublicKey
-}
-
-// The DeleteAccount action.
-type DeleteAccount struct {
-	BeneficiaryID string
-}
-
-// A Signature used for signing transaction.
-type Signature struct {
-	KeyType uint8
-	Data    [64]byte
-}
-
-// SignedTransaction encodes signed transactions for NEAR.
-type SignedTransaction struct {
-	Transaction Transaction
-	Signature   Signature
-}
-
 func createTransaction(
 	signerID string,
-	publicKey utils.PublicKey,
+	publicKey ed25519.PublicKey,
 	receiverID string,
 	nonce uint64,
 	blockHash []byte,
-	actions []Action,
-) *Transaction {
-	var tx Transaction
+	actions []types.Action,
+) *types.Transaction {
+	var tx types.Transaction
 	tx.SignerID = signerID
-	tx.PublicKey = publicKey
+	tx.PublicKey.FromEd25519(publicKey)
 	tx.ReceiverID = receiverID
 	tx.Nonce = nonce
 	copy(tx.BlockHash[:], blockHash)
@@ -136,10 +39,9 @@ func createTransaction(
 }
 
 func signTransactionObject(
-	tx *Transaction,
+	tx *types.Transaction,
 	privKey ed25519.PrivateKey,
-	accountID string,
-) (txHash []byte, signedTx *SignedTransaction, err error) {
+) (txHash []byte, signedTx *types.SignedTransaction, err error) {
 	buf, err := borsh.Serialize(*tx)
 	if err != nil {
 		return nil, nil, err
@@ -152,11 +54,11 @@ func signTransactionObject(
 		return nil, nil, err
 	}
 
-	var signature Signature
-	signature.KeyType = utils.ED25519
+	var signature types.Signature
+	signature.KeyType = types.ED25519
 	copy(signature.Data[:], sig)
 
-	var stx SignedTransaction
+	var stx types.SignedTransaction
 	stx.Transaction = *tx
 	stx.Signature = signature
 
@@ -166,18 +68,18 @@ func signTransactionObject(
 func signTransaction(
 	receiverID string,
 	nonce uint64,
-	actions []Action,
+	actions []types.Action,
 	blockHash []byte,
 	publicKey ed25519.PublicKey,
 	privKey ed25519.PrivateKey,
 	accountID string,
-) (txHash []byte, signedTx *SignedTransaction, err error) {
+) (txHash []byte, signedTx *types.SignedTransaction, err error) {
 	// create transaction
-	tx := createTransaction(accountID, utils.PublicKeyFromEd25519(publicKey),
+	tx := createTransaction(accountID, publicKey,
 		receiverID, nonce, blockHash, actions)
 
 	// sign transaction object
-	txHash, signedTx, err = signTransactionObject(tx, privKey, accountID)
+	txHash, signedTx, err = signTransactionObject(tx, privKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aurora-is-near/near-api-go/types"
-	"github.com/aurora-is-near/near-api-go/utils"
 	"github.com/near/borsh-go"
 )
 
@@ -21,7 +20,7 @@ func TestSignedTransactionStruct(t *testing.T) {
 		t.Fatalf("Deserialization error: %v", err)
 	}
 
-	ok, err := utils.VerifyTransactionSignature(&signedTx)
+	ok, err := VerifyTransactionSignature(&signedTx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/aurora-is-near/near-api-go/types"
+	"github.com/aurora-is-near/near-api-go/utils"
 	"github.com/near/borsh-go"
 )
 
@@ -14,8 +16,16 @@ func TestSignedTransactionStruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var signedTx SignedTransaction
+	var signedTx types.SignedTransaction
 	if err = borsh.Deserialize(&signedTx, buf); err != nil {
+		t.Fatalf("Deserialization error: %v", err)
+	}
+
+	ok, err := utils.VerifyTransactionSignature(&signedTx)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("signature is not valid")
 	}
 }

--- a/types/crypto.go
+++ b/types/crypto.go
@@ -19,14 +19,14 @@ type PublicKey struct {
 }
 
 
-func (pk *PublicKey) FromEd25519(edPk ed25519.PublicKey) {
-	pk.KeyType = ED25519
-	copy(pk.Data[:], edPk)
+func (pubKey *PublicKey) FromEd25519(edPk ed25519.PublicKey) {
+	pubKey.KeyType = ED25519
+	copy(pubKey.Data[:], edPk)
 }
 
 
-func (pk *PublicKey) ToEd25519() ed25519.PublicKey {
-	return ed25519.PublicKey(pk.Data[:])
+func (pubKey *PublicKey) ToEd25519() ed25519.PublicKey {
+	return ed25519.PublicKey(pubKey.Data[:])
 }
 
 // AccessKey encodes a NEAR access key.

--- a/types/crypto.go
+++ b/types/crypto.go
@@ -1,0 +1,126 @@
+package types
+
+import (
+	"crypto/ed25519"
+	"math/big"
+
+	"github.com/near/borsh-go"
+)
+
+// All supported key types
+const (
+	ED25519 = 0
+)
+
+// PublicKey encoding for NEAR.
+type PublicKey struct {
+	KeyType uint8
+	Data    [32]byte
+}
+
+
+func (pk *PublicKey) FromEd25519(edPk ed25519.PublicKey) {
+	pk.KeyType = ED25519
+	copy(pk.Data[:], edPk)
+}
+
+
+func (pk *PublicKey) ToEd25519() ed25519.PublicKey {
+	return ed25519.PublicKey(pk.Data[:])
+}
+
+// AccessKey encodes a NEAR access key.
+type AccessKey struct {
+	Nonce      uint64
+	Permission AccessKeyPermission
+}
+
+// AccessKeyPermission encodes a NEAR access key permission.
+type AccessKeyPermission struct {
+	Enum         borsh.Enum `borsh_enum:"true"` // treat struct as complex enum when serializing/deserializing
+	FunctionCall FunctionCallPermission
+	FullAccess   borsh.Enum
+}
+
+// FunctionCallPermission encodes a NEAR function call permission (an access
+// key permission).
+type FunctionCallPermission struct {
+	Allowance   *big.Int
+	ReceiverId  string
+	MethodNames []string
+}
+
+// A Transaction encodes a NEAR transaction.
+type Transaction struct {
+	SignerID   string
+	PublicKey  PublicKey
+	Nonce      uint64
+	ReceiverID string
+	BlockHash  [32]byte
+	Actions    []Action
+}
+
+// Action simulates an enum for Borsh encoding.
+type Action struct {
+	Enum           borsh.Enum `borsh_enum:"true"` // treat struct as complex enum when serializing/deserializing
+	CreateAccount  borsh.Enum
+	DeployContract DeployContract
+	FunctionCall   FunctionCall
+	Transfer       Transfer
+	Stake          Stake
+	AddKey         AddKey
+	DeleteKey      DeleteKey
+	DeleteAccount  DeleteAccount
+}
+
+// The DeployContract action.
+type DeployContract struct {
+	Code []byte
+}
+
+// The FunctionCall action.
+type FunctionCall struct {
+	MethodName string
+	Args       []byte
+	Gas        uint64
+	Deposit    big.Int // u128
+}
+
+// The Transfer action.
+type Transfer struct {
+	Deposit big.Int // u128
+}
+
+// The Stake action.
+type Stake struct {
+	Stake     big.Int // u128
+	PublicKey PublicKey
+}
+
+// The AddKey action.
+type AddKey struct {
+	PublicKey PublicKey
+	AccessKey AccessKey
+}
+
+// The DeleteKey action.
+type DeleteKey struct {
+	PublicKey PublicKey
+}
+
+// The DeleteAccount action.
+type DeleteAccount struct {
+	BeneficiaryID string
+}
+
+// A Signature used for signing transaction.
+type Signature struct {
+	KeyType uint8
+	Data    [64]byte
+}
+
+// SignedTransaction encodes signed transactions for NEAR.
+type SignedTransaction struct {
+	Transaction Transaction
+	Signature   Signature
+}

--- a/utils/key_pair.go
+++ b/utils/key_pair.go
@@ -5,24 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aurora-is-near/near-api-go/types"
 	"github.com/btcsuite/btcd/btcutil/base58"
 )
 
-// All supported key types
-const (
-	ED25519 = 0
-)
-
-// PublicKey encoding for NEAR.
-type PublicKey struct {
-	KeyType uint8
-	Data    [32]byte
-}
-
 // PublicKeyFromEd25519 derives a public key in NEAR encoding from pk.
-func PublicKeyFromEd25519(pk ed25519.PublicKey) PublicKey {
-	var pubKey PublicKey
-	pubKey.KeyType = ED25519
+func PublicKeyFromEd25519(pk ed25519.PublicKey) types.PublicKey {
+	var pubKey types.PublicKey
+	pubKey.KeyType = types.ED25519
 	copy(pubKey.Data[:], pk)
 	return pubKey
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,2 +1,22 @@
 // Package utils implements helper functions for the Go NEAR API.
 package utils
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil/base58"
+)
+
+// Ed25519SignatureFromString derives an ed25519 signature from its base58 string representation prefixed with 'ed25519:'.
+func Ed25519SignatureFromString(ed25519Signature string) ([]byte, error) {
+	if !strings.HasPrefix(ed25519Signature, ed25519Prefix) {
+		return nil, fmt.Errorf("'%s' is not an Ed25519 signature", ed25519Signature)
+	}
+	signatureBytes := base58.Decode(strings.TrimPrefix(ed25519Signature, ed25519Prefix))
+	if len(signatureBytes) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("unexpected byte length for signature '%s'", ed25519Signature)
+	}
+	return signatureBytes, nil
+}

--- a/utils/verify_signature.go
+++ b/utils/verify_signature.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"errors"
+
+	"github.com/aurora-is-near/near-api-go/types"
+	"github.com/near/borsh-go"
+)
+
+// VerifyTransactionSignature verifies the signature of a given signed transaction.
+// It returns true if the signature is valid, false otherwise.
+func VerifyTransactionSignature(signedTx *types.SignedTransaction) (bool, error) {
+	// Serialize the unsigned transaction
+	unsignedTx := signedTx.Transaction
+	serializedTx, err := borsh.Serialize(unsignedTx)
+	if err != nil {
+		return false, err
+	}
+
+	// Compute the hash of the serialized transaction
+	txHash := sha256.Sum256(serializedTx)
+
+	// Extract the public key from the transaction
+	publicKeyData := unsignedTx.PublicKey.Data[:]
+	if unsignedTx.PublicKey.KeyType != types.ED25519 {
+		return false, errors.New("unsupported key type")
+	}
+
+	// Extract the signature from the signed transaction
+	signatureData := signedTx.Signature.Data[:]
+	if signedTx.Signature.KeyType != types.ED25519 {
+		return false, errors.New("unsupported signature key type")
+	}
+
+	// Verify the signature
+	isValid := ed25519.Verify(publicKeyData, txHash[:], signatureData)
+	if !isValid {
+		return false, errors.New("invalid signature")
+	}
+
+	return true, nil
+}

--- a/verify_signature.go
+++ b/verify_signature.go
@@ -59,12 +59,16 @@ func VerifySignatureBytes(publicKey []byte, signature []byte, message []byte) (b
 }
 
 // Verify signature of a given public key and signature as a hex string
-func VerifySignatureHex(publicKeyHex string, signatureHex string, message []byte) (bool, error) {
+func VerifySignatureHex(publicKeyHex string, signatureHex string, messageHex string) (bool, error) {
 	publicKey, err := hex.DecodeString(publicKeyHex)
 	if err != nil {
 		return false, err
 	}
 	signature, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return false, err
+	}
+	message, err := hex.DecodeString(messageHex)
 	if err != nil {
 		return false, err
 	}

--- a/verify_signature.go
+++ b/verify_signature.go
@@ -1,4 +1,4 @@
-package utils
+package near
 
 import (
 	"crypto/ed25519"

--- a/verify_signature.go
+++ b/verify_signature.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/aurora-is-near/near-api-go/types"
+	"github.com/aurora-is-near/near-api-go/utils"
 	"github.com/near/borsh-go"
 )
 
@@ -73,4 +74,34 @@ func VerifySignatureHex(publicKeyHex string, signatureHex string, messageHex str
 		return false, err
 	}
 	return VerifySignatureBytes(publicKey, signature, message)
+}
+
+// VerifySignature verifies a signature given the public key, signature, and message as strings.
+// The public key and signature should be in the "ed25519:..." format.
+func VerifySignatureBase58(pubKeyStr, signatureStr, messageHex string) (bool, error) {
+	// Parse the public key
+	pubKey, err := utils.Ed25519PublicKeyFromString(pubKeyStr)
+	if err != nil {
+		return false, err
+	}
+
+	// Parse the signature
+	signature, err := utils.Ed25519SignatureFromString(signatureStr)
+	if err != nil {
+		return false, err
+	}
+
+	// Decode the message from hex
+	messageBytes, err := hex.DecodeString(messageHex)
+	if err != nil {
+		return false, err
+	}
+
+	// Hash the message
+	hash := sha256.Sum256(messageBytes)
+
+	// Verify the signature
+	isValid := ed25519.Verify(pubKey, hash[:], signature)
+
+	return isValid, nil
 }

--- a/verify_signature.go
+++ b/verify_signature.go
@@ -3,6 +3,7 @@ package near
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 
 	"github.com/aurora-is-near/near-api-go/types"
@@ -41,4 +42,31 @@ func VerifyTransactionSignature(signedTx *types.SignedTransaction) (bool, error)
 	}
 
 	return true, nil
+}
+
+// Verify signature of a given public key and signature
+func VerifySignatureBytes(publicKey []byte, signature []byte, message []byte) (bool, error) {
+	pubKey := types.PublicKey{}
+	pubKey.FromEd25519(publicKey)
+
+	signatureData := signature[:]
+	if len(signatureData) != ed25519.SignatureSize {
+		return false, errors.New("invalid signature size")
+	}
+
+	hash := sha256.Sum256(message)
+	return ed25519.Verify(pubKey.ToEd25519(), hash[:], signatureData), nil
+}
+
+// Verify signature of a given public key and signature as a hex string
+func VerifySignatureHex(publicKeyHex string, signatureHex string, message []byte) (bool, error) {
+	publicKey, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		return false, err
+	}
+	signature, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		return false, err
+	}
+	return VerifySignatureBytes(publicKey, signature, message)
 }

--- a/verify_signature_test.go
+++ b/verify_signature_test.go
@@ -1,0 +1,69 @@
+package near
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestVerifySignature(t *testing.T) {
+	// Generate a new key pair
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	// Create a message to sign
+	message := []byte("test message")
+	messageHex := hex.EncodeToString(message)
+
+	// Hash the message
+	hash := sha256.Sum256(message)
+
+	// Sign the hashed message
+	signature := ed25519.Sign(privKey, hash[:])
+	signatureHex := hex.EncodeToString(signature)
+
+	// Verify the signature
+	isValid, err := VerifySignatureBytes(pubKey, signature, message)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if !isValid {
+		t.Fatal("Signature is not valid")
+	}
+
+	// Test invariant: Verify that the signature is invalid for a different message
+	otherMessage := []byte("different message")
+	isValid, err = VerifySignatureBytes(pubKey, signature, otherMessage)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if isValid {
+		t.Fatal("Signature should not be valid for a different message")
+	}
+
+	// Test invariant: Verify that the signature is invalid for a different public key
+	otherPubKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+	isValid, err = VerifySignatureBytes(otherPubKey, signature, message)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if isValid {
+		t.Fatal("Signature should not be valid for a different public key")
+	}
+
+	// Test VerifySignatureHex
+	isValid, err = VerifySignatureHex(hex.EncodeToString(pubKey), signatureHex, messageHex)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if !isValid {
+		t.Fatal("Signature should be valid for a different public key")
+	}
+}

--- a/verify_signature_test.go
+++ b/verify_signature_test.go
@@ -16,7 +16,7 @@ func TestVerifySignature(t *testing.T) {
 	}
 
 	// Create a message to sign
-	message := []byte("test message")
+	message := []byte("+16005551111evm.test-account.testnet")
 	messageHex := hex.EncodeToString(message)
 
 	// Hash the message
@@ -78,6 +78,24 @@ func TestVerifySignaturePrecomputed(t *testing.T) {
 
 	// Verify the signature
 	isValid, err := VerifySignatureHex(pubKey, signature, messageHex)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if !isValid {
+		t.Fatal("Signature should be valid for the given public key")
+	}
+}
+
+func TestVerifySignatureString(t *testing.T) {
+	message := "+16005551111evm.test-account.testnet"
+	pubKey := "ed25519:3MVWwQTnSU8RVNe1Z5Ytv9zVE16aXLuHkvEha4LvDH1z"
+	signature := "ed25519:3cn6uwA9hVtK8S4ib2coEt8HTV1pjuCLtZs5iUx4zKmXhAUd73rhXcmG2icFk1mF5zy4B2wVkjoisWZQczDG5nXV"
+
+	// Convert message to hex
+	messageHex := hex.EncodeToString([]byte(message))
+
+	// Verify the signature
+	isValid, err := VerifySignatureBase58(pubKey, signature, messageHex)
 	if err != nil {
 		t.Fatalf("Failed to verify signature: %v", err)
 	}

--- a/verify_signature_test.go
+++ b/verify_signature_test.go
@@ -64,6 +64,24 @@ func TestVerifySignature(t *testing.T) {
 		t.Fatalf("Failed to verify signature: %v", err)
 	}
 	if !isValid {
-		t.Fatal("Signature should be valid for a different public key")
+		t.Fatal("Signature should be valid for the given public key")
+	}
+}
+
+func TestVerifySignaturePrecomputed(t *testing.T) {
+	message := "+16005551111evm.test-account.testnet"
+	pubKey := "86fd8e75c00c88ad489b3c0c7dd8d13ef0953d4b03788acb05b281b2acd2bf86"
+	signature := "a45ea2a6999a69b35a8a9fc3eb60f2440c1d4f7a45641eb81f309a27dbd0342258159d99cd4f322deec8f028214e72072480c9d145b25d5f0f0f3df8f8f9c30b"
+
+	// Convert message to hex
+	messageHex := hex.EncodeToString([]byte(message))
+
+	// Verify the signature
+	isValid, err := VerifySignatureHex(pubKey, signature, messageHex)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+	if !isValid {
+		t.Fatal("Signature should be valid for the given public key")
 	}
 }


### PR DESCRIPTION
Added **VerifyTransactionSignature** function:
- Verifies the signature of a SignedTransaction.
- Uses Borsh serialization and SHA-256 hashing.
- Supports ED25519 key type for verification.

Example usage:
```package main

import (
    "fmt"
    "github.com/aurora-is-near/near-api-go/near"
)

func main() {
    var signedTx *near.SignedTransaction
    // Initialize signedTx...

    isValid, err := near.VerifyTransactionSignature(signedTx)
    if err != nil {
        fmt.Println("Error:", err)
    } else if isValid {
        fmt.Println("Signature is valid.")
    } else {
        fmt.Println("Signature is invalid.")
    }
}