### PR TITLE
Add send_tx RPC method support

### DIFF
--- a/types.go
+++ b/types.go
@@ -6,20 +6,20 @@ type TxExecutionStatus string
 const (
 	// Transaction is waiting to be included into the block
 	TxExecutionStatus_None TxExecutionStatus = "NONE"
-	// Transaction is included into the block. The block may be not finalised yet
+	// Transaction is included into the block. The block may be not finalized yet
 	TxExecutionStatus_Included TxExecutionStatus = "INCLUDED"
 	// Transaction is included into the block +
 	// All non-refund transaction receipts finished their execution.
-	// The corresponding blocks for tx and each receipt may be not finalised yet
+	// The corresponding blocks for tx and each receipt may be not finalized yet
 	TxExecutionStatus_ExecutedOptimistic TxExecutionStatus = "EXECUTED_OPTIMISTIC"
-	// Transaction is included into finalised block
+	// Transaction is included into finalized block
 	TxExecutionStatus_IncludedFinal TxExecutionStatus = "INCLUDED_FINAL"
-	// Transaction is included into finalised block +
+	// Transaction is included into finalized block +
 	// All non-refund transaction receipts finished their execution.
-	// The corresponding blocks for each receipt may be not finalised yet
+	// The corresponding blocks for each receipt may be not finalized yet
 	TxExecutionStatus_Executed TxExecutionStatus = "EXECUTED"
-	// Transaction is included into finalised block +
-	// Execution of all transaction receipts is finalised, including refund receipts
+	// Transaction is included into finalized block +
+	// Execution of all transaction receipts is finalized, including refund receipts
 	TxExecutionStatus_Final TxExecutionStatus = "FINAL"
 
 	TxExecutionStatus_Default = TxExecutionStatus_ExecutedOptimistic


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new transaction methods allowing configurable waiting behavior for transaction execution status, including sending tokens and function calls with enhanced control.
- **Documentation**
	- Updated comments to use American English spelling for transaction statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->